### PR TITLE
Fixes the raw block calls in the templates.

### DIFF
--- a/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/templates/base.html
@@ -1,3 +1,6 @@
+{% if cookiecutter.project_backend == "django" %}
+{{ "{% load static %}" }}
+{% endif %}
 <html lang="en">
 <head>
     {% raw %}
@@ -71,10 +74,9 @@
                     <img class="mr-3 img-fluid" src="{{ 'res/img/astronaut.jpeg' | get_static_url_for_backend(framework=cookiecutter.project_backend) }}" alt="Astronaut looking into space" />
                 </div>
                 <div class="col-md-8">
-                    {% block content %}
-                    <h1 class="display-4 tk-elevon">Lorem Ipsum Dolor</h1>
+                    {{ "{% block content %}" }}
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                    {% endblock %}
+                    {{ "{% endblock %}" }}
                 </div>
             </div>
         </div>

--- a/{{cookiecutter.project_slug}}/templates/destinations.html
+++ b/{{cookiecutter.project_slug}}/templates/destinations.html
@@ -15,7 +15,7 @@ If you can imagine it, we travel to it! Below is our list of confirmed destinati
     {% endraw %}
     <a class="list-group-item list-group-item-action" href="{{ 'destination' | get_detail_url_for_backend(framework=cookiecutter.project_backend) }}">
     {% raw %}
-        {{ destination }}}
+        {{ destination }}
     </a>
     {% endfor %}
 </div>


### PR DESCRIPTION
Things were running as expected but `{% raw %}{% endraw%}` was missing around the `{% block content %}` section in base causing all of the pages to show the _lorem_ boilerplate