### PR TITLE
exludes migrations from black

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/pyproject.toml
+++ b/{{cookiecutter.__src_folder_name}}/pyproject.toml
@@ -13,6 +13,7 @@ known-first-party = ["fastapi_app"]
 
 [tool.black]
 line-length = 120
+extend-exclude = "migrations"
 
 [tool.pytest.ini_options]
 addopts = "-ra --cov -vv"


### PR DESCRIPTION
deployment tests were failing because of black seeing a problem in the migration files. this setting will pass an ignore on all files in `migrations` which should catch both django-migrations and alembic-migrations.