### PR TITLE
Adds postgres service for ACA

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "project_host": ["aca", "appservice"],
   "project_backend": ["django", "fastapi", "flask"],
   "use_vnet": "n",
-  "db_resource": ["postgres-flexible", "cosmos-postgres"],
+  "db_resource": ["postgres-flexible", "cosmos-postgres", "postgres-service"],
   "__repo_name": "{{cookiecutter.project_name}}-{{cookiecutter.project_backend}}-{{cookiecutter.db_resource}}-{{cookiecutter.project_host}}",
   "__src_folder_name": "{{ cookiecutter.__repo_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_')|trim() }}",
   "__project_short_description": "Create a relecloud demo application with {{cookiecutter.project_backend}} and {{cookiecutter.db_resource}}",

--- a/{{cookiecutter.__src_folder_name}}/.devcontainer/docker-compose_dev.yml
+++ b/{{cookiecutter.__src_folder_name}}/.devcontainer/docker-compose_dev.yml
@@ -16,11 +16,11 @@ services:
       context: .
       dockerfile: .devcontainer/Dockerfile_dev
     environment:
-      DBSERVER_USER: postgres
-      DBSERVER_DB: relecloud
-      DBSERVER_HOST: db
-      DBSERVER_PORT: 5432
-      DBSERVER_PASSWORD: postgres
+      POSTGRES_USERNAME: postgres
+      POSTGRES_DATABASE: relecloud
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_PASSWORD: postgres
 
     command: sleep infinity
 

--- a/{{cookiecutter.__src_folder_name}}/infra/core/database/postgresql/aca-service.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/database/postgresql/aca-service.bicep
@@ -1,0 +1,49 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+
+param containerAppsEnvironmentId string
+
+resource postgres 'Microsoft.App/containerApps@2023-04-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      service: {
+          type: 'postgres'
+      }
+    }
+  }
+}
+
+/*
+resource pgsqlCli 'Microsoft.App/containerApps@2023-04-01-preview' = {
+  name: '${name}-cli'
+  location: location
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    template: {
+      serviceBinds: [
+        {
+          serviceId: postgres.id
+        }
+      ]
+      containers: [
+        {
+          name: 'psql'
+          image: 'mcr.microsoft.com/k8se/services/postgres:14'
+          command: [ '/bin/sleep', 'infinity' ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+*/
+
+output id string = postgres.id

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app-upsert.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app-upsert.bicep
@@ -34,6 +34,10 @@ param daprAppId string = containerName
 @description('Protocol used by Dapr to connect to the app, e.g. http or grpc')
 param daprAppProtocol string = 'http'
 
+// Service options
+@description('PostgreSQL service ID')
+param postgresServiceId string
+
 @description('CPU cores allocated to a single container instance, e.g. 0.5')
 param containerCpuCoreCount string = '0.5'
 
@@ -62,6 +66,7 @@ module app 'container-app.bicep' = {
     daprEnabled: daprEnabled
     daprAppId: daprAppId
     daprAppProtocol: daprAppProtocol
+    postgresServiceId: postgresServiceId
     secrets: secrets
     external: external
     env: env

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app-upsert.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app-upsert.bicep
@@ -36,7 +36,7 @@ param daprAppProtocol string = 'http'
 
 // Service options
 @description('PostgreSQL service ID')
-param postgresServiceId string
+param postgresServiceId string = ''
 
 @description('CPU cores allocated to a single container instance, e.g. 0.5')
 param containerCpuCoreCount string = '0.5'

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app.bicep
@@ -34,6 +34,10 @@ param daprAppId string = containerName
 @description('Protocol used by Dapr to connect to the app, e.g. http or grpc')
 param daprAppProtocol string = 'http'
 
+// Service options
+@description('PostgreSQL service ID')
+param postgresServiceId string
+
 @description('CPU cores allocated to a single container instance, e.g. 0.5')
 param containerCpuCoreCount string = '0.5'
 
@@ -52,7 +56,7 @@ module containerRegistryAccess '../security/registry-access.bicep' = {
   }
 }
 
-resource app 'Microsoft.App/containerApps@2022-03-01' = {
+resource app 'Microsoft.App/containerApps@2023-04-01-preview' = {
   name: name
   location: location
   tags: tags
@@ -89,6 +93,12 @@ resource app 'Microsoft.App/containerApps@2022-03-01' = {
       ]
     }
     template: {
+      serviceBinds: !empty(postgresServiceId) ? [
+        {
+          serviceId: postgresServiceId
+          name: 'postgres'
+        }
+      ] : []
       containers: [
         {
           image: !empty(imageName) ? imageName : 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-app.bicep
@@ -36,7 +36,7 @@ param daprAppProtocol string = 'http'
 
 // Service options
 @description('PostgreSQL service ID')
-param postgresServiceId string
+param postgresServiceId string = ''
 
 @description('CPU cores allocated to a single container instance, e.g. 0.5')
 param containerCpuCoreCount string = '0.5'

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-apps-environment.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-apps-environment.bicep
@@ -32,3 +32,4 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing
 
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
 output name string = containerAppsEnvironment.name
+output id string = containerAppsEnvironment.id

--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/container-apps.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/container-apps.bicep
@@ -29,5 +29,6 @@ module containerRegistry 'container-registry.bicep' = {
 
 output defaultDomain string = containerAppsEnvironment.outputs.defaultDomain
 output environmentName string = containerAppsEnvironment.outputs.name
+output environmentId string = containerAppsEnvironment.outputs.id
 output registryLoginServer string = containerRegistry.outputs.loginServer
 output registryName string = containerRegistry.outputs.name

--- a/{{cookiecutter.__src_folder_name}}/infra/main.parameters.json
+++ b/{{cookiecutter.__src_folder_name}}/infra/main.parameters.json
@@ -13,10 +13,10 @@
       },
       "webAppExists": {
         "value": "${SERVICE_WEB_RESOURCE_EXISTS=false}"
-      },
+      }{% if cookiecutter.db_resource in ("postgres-flexible", "cosmos-postgres") %},
       "dbserverPassword": {
         "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} DBSERVERPASSWORD)"
-      }{% if cookiecutter.project_backend in ("django", "flask") %},
+      }{% endif %}{% if cookiecutter.project_backend in ("django", "flask") %},
       "secretKey": {
         "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} SECRETKEY)"
       }

--- a/{{cookiecutter.__src_folder_name}}/infra/web.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/web.bicep
@@ -19,7 +19,9 @@ param dbserverPassword string
 @secure()
 param secretKey string
 {% endif %}
+{% if cookiecutter.db_resource == "postgres-service" %}
 param postgresServiceId string
+{% endif %}
 
 resource webIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: identityName

--- a/{{cookiecutter.__src_folder_name}}/src/django/project/settings.py
+++ b/{{cookiecutter.__src_folder_name}}/src/django/project/settings.py
@@ -102,11 +102,14 @@ OPENCENSUS = {
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("DBSERVER_DB"),
-        "USER": os.environ.get("DBSERVER_USER"),
-        "PASSWORD": os.environ.get("DBSERVER_PASSWORD"),
-        "HOST": os.environ.get("DBSERVER_HOST"),
-        "PORT": os.environ.get("DBSERVER_PORT"),
+        {% if cookiecutter.db_resource == "postgres-service" %}
+        # The PostgreSQL service binding will always set env variables with these names.
+        {% endif %}
+        "NAME": os.environ.get("POSTGRES_DATABASE"),
+        "USER": os.environ.get("POSTGRES_USERNAME"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
+        "HOST": os.environ.get("POSTGRES_HOST"),
+        "PORT": os.environ.get("POSTGRES_PORT"),
     }
 }
 

--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
@@ -5,14 +5,17 @@ import typing
 
 from sqlmodel import Field, Relationship, SQLModel, create_engine
 
-DBSERVER_USER = os.environ.get("DBSERVER_USER")
-DBSERVER_PASSWORD = os.environ.get("DBSERVER_PASSWORD")
-DBSERVER_HOST = os.environ.get("DBSERVER_HOST")
-DBSERVER_DB = os.environ.get("DBSERVER_DB")
+{% if cookiecutter.db_resource == "postgres-service" %}
+# The PostgreSQL service binding will always set env variables with these names.
+{% endif %}
+POSTGRES_USERNAME = os.environ.get("POSTGRES_USERNAME")
+POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
+POSTGRES_HOST = os.environ.get("POSTGRES_HOST")
+POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE")
 
-sql_url = f"postgresql://{DBSERVER_USER}:{DBSERVER_PASSWORD}@{DBSERVER_HOST}/{DBSERVER_DB}"
+sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}/{POSTGRES_DATABASE}"
 
-if os.environ.get("RUNNING_IN_PRODUCTION", False):
+if os.environ.get("POSTGRES_SSL", "disable") != "disable":
     sql_url = f"{sql_url}?sslmode=require"
 
 engine = create_engine(sql_url, echo=True)

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/development.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/development.py
@@ -6,10 +6,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 DEBUG = True
 
-dbuser = os.environ["DBSERVER_USER"]
-dbpass = os.environ["DBSERVER_PASSWORD"]
-dbhost = os.environ["DBSERVER_HOST"]
-dbname = os.environ["DBSERVER_DB"]
+dbuser = os.environ["POSTGRES_USERNAME"]
+dbpass = os.environ["POSTGRES_PASSWORD"]
+dbhost = os.environ["POSTGRES_HOST"]
+dbname = os.environ["POSTGRES_DATABASE"]
 DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}"
 
 TIME_ZONE = "UTC"

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
@@ -7,10 +7,11 @@ if "WEBSITE_HOSTNAME" in os.environ:
 else:
     ALLOWED_HOSTS = []
 
-# Configure Postgres database; the full username for PostgreSQL flexible server is
-# username (not @server-name).
-dbuser = os.environ["DBSERVER_USER"]
-dbpass = os.environ["DBSERVER_PASSWORD"]
-dbhost = os.environ["DBSERVER_HOST"]
-dbname = os.environ["DBSERVER_DB"]
+{% if cookiecutter.db_resource == "postgres-service" %}
+# The PostgreSQL service binding will always set env variables with these names.
+{% endif %}
+dbuser = os.environ["POSTGRES_USERNAME"]
+dbpass = os.environ["POSTGRES_PASSWORD"]
+dbhost = os.environ["POSTGRES_HOST"]
+dbname = os.environ["POSTGRES_DATABASE"]
 DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}"


### PR DESCRIPTION
Adds postgres service using Bicep suggested at:

https://learn.microsoft.com/en-us/azure/container-apps/tutorial-dev-services-postgresql?tabs=bash#bicep-8

This required changing all the env variables, unfortunately, since the service binding automatically injects env variables with particularly naming scheme. We'll see if this makes Mongo integration awkward- current theory is that Mongo is different enough that it make sense for env vars to be different.

We may want to put in some sort of pre-gen hook to confirm a user only asks for this in combination with ACA. Feels like something cookiecutter would have existing support for, telling you valid combinations, but maybe not. I think cookiecutter-django may have similar logic.