### PR TITLE
postCreateCommand for FastAPI

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.__src_folder_name}}/.devcontainer/devcontainer.json
@@ -76,7 +76,9 @@
     "postCreateCommand": "pip install -r requirements-dev.in && pip install -e src"
     {% endif %}
     {% endif %}
-
+    {% if cookiecutter.project_backend == "fastapi" %}
+    "postCreateCommand": "pip install -r requirements-dev.in && pip install -e src && python3 src/fastapi_app/seed_data.py"
+    {% endif %}
 }
 
 {% endblock %}


### PR DESCRIPTION
The lack of this command may be why fastapi tests werent passing for you - the app needs to be installed first. This command mirrors whats in readme as well.