### PR TITLE
Provide instructions for local test running, and dont hardcode port for Flask

### DIFF
--- a/templates/conftest_flask_postgres.py
+++ b/templates/conftest_flask_postgres.py
@@ -4,8 +4,9 @@ def app():
     """Session-wide test `Flask` application."""
     config_override = {
         "TESTING": True,
+        # Allows for override of database to separate test from dev environments
         "SQLALCHEMY_DATABASE_URI": os.environ.get(
-            "TEST_DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres"
+            "TEST_DATABASE_URL", os.environ.get("DATABASE_URI")
         ),
     }
     app = create_app(config_override)

--- a/{{cookiecutter.__src_folder_name}}/README.md
+++ b/{{cookiecutter.__src_folder_name}}/README.md
@@ -8,7 +8,19 @@ This project deploys a web application for a space travel agency using {{web_fra
 
 This project has [Dev Container support](https://code.visualstudio.com/docs/devcontainers/containers), so it will be setup automatically if you open it in Github Codespaces or in local VS Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-If you're not using one of those options for opening the project, then you'll need to:
+If you're *not* using one of those options for opening the project, then you'll need to:
+
+{% if "postgres" in cookiecutter.db_resource %}
+1. Start up a local PostgreSQL server, create a database for the app, and set the following environment variables according to your database configuration.
+
+```shell
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_DATABASE=<YOUR DATABASE>
+export POSTGRES_USERNAME=<YOUR USERNAME>
+export POSTGRES_PASSWORD=<YOUR PASSWORD>
+```
+{% endif %}
 
 1. Create a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments) and activate it.
 

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/development.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/development.py
@@ -11,7 +11,8 @@ dbuser = os.environ["POSTGRES_USERNAME"]
 dbpass = os.environ["POSTGRES_PASSWORD"]
 dbhost = os.environ["POSTGRES_HOST"]
 dbname = os.environ["POSTGRES_DATABASE"]
-DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}"
+dbport = os.environ.get("POSTGRES_POST", 5432)
+DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}:{dbport}/{dbname}"
 {% endif %}
 
 {% if 'mongo' in cookiecutter.db_resource %}


### PR DESCRIPTION
Related to https://github.com/kjaymiller/cookiecutter-relecloud/issues/225 but not a direct fix. I was able to get tests running correctly with these changes, but my changes wouldn't have helped with the issue reported there. I am guessing that my tests ran correctly due to either environment differences or a recent pytest-flask update. I'll ask them to try again after this round of fixes.