### PR TITLE
Fix up FastAPI tests

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/README.md
+++ b/{{cookiecutter.__src_folder_name}}/README.md
@@ -99,7 +99,7 @@ python3 src/manage.py createsuperuser
 
     ```sh
     python3 -m pip install -r requirements-dev.in
-    playwright install --with-deps
+    python3 -m playwright install --with-deps
     ```
 
 3. Run the tests:

--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
@@ -12,8 +12,9 @@ POSTGRES_USERNAME = os.environ.get("POSTGRES_USERNAME")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST")
 POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE")
+POSTGRES_PORT = os.environ.get("POSTGRES_PORT")
 
-sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}/{POSTGRES_DATABASE}"
+sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DATABASE}"
 
 if os.environ.get("POSTGRES_SSL", "disable") != "disable":
     sql_url = f"{sql_url}?sslmode=require"

--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/seed_data.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/seed_data.py
@@ -50,6 +50,9 @@ def load_from_json():
 
 
 def drop_all():
+    # Explicitly remove these tables first to avoid cascade errors
+    SQLModel.metadata.remove(models.Cruise.__table__)
+    SQLModel.metadata.remove(models.Destination.__table__)
     SQLModel.metadata.drop_all(models.engine)
 
 

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -1,6 +1,8 @@
 {# standard library imports #}
 {% if cookiecutter.project_backend == "fastapi" %}
 from multiprocessing import Process
+import socket
+import time
 {% endif %}
 {% if cookiecutter.project_backend == "flask" %}
 import os
@@ -19,6 +21,7 @@ from flask import url_for
 import mongoengine as engine
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}
+import requests
 import uvicorn
 {% endif %}
 {% if cookiecutter.project_backend == "django" %}
@@ -39,18 +42,36 @@ from flaskapp import db
 {% endif %}
 
 {% if cookiecutter.project_backend == "fastapi" %}
-def run_server():
-    uvicorn.run(app)
+def wait_for_server_ready(
+    url: str, timeout: float = 10.0, check_interval: float = 0.5
+) -> bool:
+    """Make requests to provided url until it responds without error."""
+    conn_error = None
+    for _ in range(int(timeout / check_interval)):
+        try:
+            requests.get(url)
+        except requests.ConnectionError as exc:
+            time.sleep(check_interval)
+            conn_error = str(exc)
+        else:
+            return True
+    raise RuntimeError(conn_error)
 
 
 @pytest.fixture(scope="session")
-def live_server():
-    seed_data.load_from_json()
-    proc = Process(target=run_server, daemon=True)
-    proc.start()
-    yield
-    proc.kill()
-    seed_data.drop_all()
+def free_port() -> int:
+    """
+    Return a free port on localhost
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        addr = s.getsockname()
+        port = addr[1]
+        return port
+
+
+def run_server(port):
+    uvicorn.run(app, port=port)
 {% endif %}
 
 {% if cookiecutter.project_backend == "flask" %}
@@ -85,9 +106,16 @@ def live_server_url(live_server):
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}
 @pytest.fixture(scope="session")
-def live_server_url(live_server):
+def live_server_url(free_port: int):
     """Returns the url of the live server"""
-    return "http://localhost:{{cookiecutter.web_port}}"
+    seed_data.load_from_json()
+    proc = Process(target=run_server, args=(free_port,), daemon=True)
+    proc.start()
+    url = f"http://localhost:{free_port}"
+    wait_for_server_ready(url, timeout=10.0, check_interval=0.5)
+    yield url
+    proc.kill()
+    seed_data.drop_all()
 {% endif %}
 {% if cookiecutter.project_backend == "flask" %}
 @pytest.fixture(scope="function")


### PR DESCRIPTION
These were fixes I needed to get FastAPI tests running on local Mac. I started down this path when trying to replicate https://github.com/Azure-Samples/azure-fastapi-postgres-flexible-aca/issues/12 which I haven't replicated successfully, but these fixes may help.

I changed conftest to match what we do in the OpenAI sample that has worked well:
https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/tests/e2e.py

Big differences: Adding a dynamically chosen port, polling to make sure server is ready.

Also this PR has a workaround for https://github.com/kjaymiller/cookiecutter-relecloud/issues/244 since it's unclear to me why drop_all() isn't working correctly.