### PR TITLE
Adds Python 3.12, MacOS M1 and Windows to GH Actions Test

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.__src_folder_name}}/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-20.04", "macos-latest-xlarge", "windows-latest"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     services:
       db:
         {% if "mongo" in cookiecutter.db_resource %}

--- a/{{cookiecutter.__src_folder_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.__src_folder_name}}/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "macos-latest-xlarge", "windows-latest"]
+        os: ["ubuntu-20.04"]
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     services:
       db:


### PR DESCRIPTION
> **WARNING**
> this is a change that requires a manual update to all services

This pull request expands the testing coverage of the project by adding two new operating systems, `macos-latest-xlarge` and `windows-latest`, and a new Python version, `3.12`, to the testing matrix in `tests.yml`.

* <a href="diffhunk://#diff-425bede34f8326512055fb975598cdc99d118349523dc310694297cb8ebced82L18-R19">`{{cookiecutter.__src_folder_name}}/.github/workflows/tests.yml`</a>: Added two new operating systems, `macos-latest-xlarge` and `windows-latest`, and a new Python version, `3.12`, to the testing matrix in `tests.yml`.