### PR TITLE
Update production settings with sslmode=require

### DIFF
--- a/templates/web_macros.bicep
+++ b/templates/web_macros.bicep
@@ -16,6 +16,10 @@
   name: 'POSTGRES_PASSWORD'
   secretRef: 'dbserver-password'
 }
+{
+  name: 'POSTGRES_SSL'
+  value: 'require'
+}
 {% endif %}
 {% endmacro %}
 

--- a/{{cookiecutter.__src_folder_name}}/infra/aca.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/aca.bicep
@@ -71,6 +71,10 @@ module app 'core/host/container-app-upsert.bicep' = {
         name: 'POSTGRES_PASSWORD'
         secretRef: 'dbserver-password'
       }
+      {
+        name: 'POSTGRES_SSL'
+        value: 'require'
+      }
       {% endif %}
       {% endif %}
       {

--- a/{{cookiecutter.__src_folder_name}}/infra/appservice.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/appservice.bicep
@@ -51,6 +51,7 @@ module web 'core/host/appservice.bicep' = {
       POSTGRES_USERNAME: dbserverUser
       POSTGRES_DATABASE: dbserverDatabaseName
       POSTGRES_PASSWORD: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=DBSERVERPASSWORD)'
+      POSTGRES_SSL: 'require'
       {% endif %}
       {% if cookiecutter.project_backend in ("django", "flask") %}
       SECRET_KEY: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=SECRETKEY)'

--- a/{{cookiecutter.__src_folder_name}}/src/django/project/settings.py
+++ b/{{cookiecutter.__src_folder_name}}/src/django/project/settings.py
@@ -109,6 +109,13 @@ OPENCENSUS = {
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
+db_options = {}
+{% if cookiecutter.db_resource == "postgres-addon" %}
+# The PostgreSQL service binding will typically set POSTGRES_SSL to disable.
+{% endif %}
+if ssl_mode := os.environ.get("POSTGRES_SSL"):
+    db_options = {"sslmode": ssl_mode}
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -119,7 +126,8 @@ DATABASES = {
         "USER": os.environ.get("POSTGRES_USERNAME"),
         "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
         "HOST": os.environ.get("POSTGRES_HOST"),
-        "PORT": os.environ.get("POSTGRES_PORT"),
+        "PORT": os.environ.get("POSTGRES_PORT", 5432),
+        "OPTIONS": db_options,
     }
 }
 

--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
@@ -13,14 +13,14 @@ POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST")
 POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE")
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT", 5432)
+POSTGRES_SSL = os.environ.get("POSTGRES_SSL")
 
 sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DATABASE}"
-
 {% if cookiecutter.db_resource == "postgres-addon" %}
 # The PostgreSQL service binding will typically set POSTGRES_SSL to disable.
-if os.environ.get("POSTGRES_SSL", "disable") != "disable":
-    sql_url = f"{sql_url}?sslmode=require"
 {% endif %}
+if POSTGRES_SSL:
+    sql_url = f"{sql_url}?sslmode={POSTGRES_SSL}"
 
 engine = create_engine(sql_url, echo=True)
 

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
@@ -24,7 +24,14 @@ dbuser = os.environ["POSTGRES_USERNAME"]
 dbpass = os.environ["POSTGRES_PASSWORD"]
 dbhost = os.environ["POSTGRES_HOST"]
 dbname = os.environ["POSTGRES_DATABASE"]
-DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}?sslmode=require"
+dbport = os.environ.get("POSTGRES_PORT", 5432)
+{% if cookiecutter.db_resource == "postgres-addon" %}
+# The PostgreSQL service binding will typically set POSTGRES_SSL to disable.
+{% endif %}
+sslmode = os.environ.get("POSTGRES_SSL")
+DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}:{dbport}/{dbname}"
+if sslmode:
+    DATABASE_URI = f"{DATABASE_URI}?sslmode={sslmode}"
 {% endif %}
 
 {% if 'mongo' in cookiecutter.db_resource %}

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/config/production.py
@@ -24,7 +24,7 @@ dbuser = os.environ["POSTGRES_USERNAME"]
 dbpass = os.environ["POSTGRES_PASSWORD"]
 dbhost = os.environ["POSTGRES_HOST"]
 dbname = os.environ["POSTGRES_DATABASE"]
-DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}"
+DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}?sslmode=require"
 {% endif %}
 
 {% if 'mongo' in cookiecutter.db_resource %}


### PR DESCRIPTION
Matches the change made here:

https://github.com/Azure-Samples/azure-flask-postgres-flexible-appservice/pull/11/files#diff-1d3bbcdf68040dc1dec7fe58a7ab710132800dea1a258fe16092363638214179

Partial fix for https://github.com/kjaymiller/cookiecutter-relecloud/issues/258 but only for Flask