### PR TITLE
Remove coverage and pytest-cov

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/pyproject.toml
+++ b/{{cookiecutter.__src_folder_name}}/pyproject.toml
@@ -28,11 +28,8 @@ force-exclude = '''
 {% endif %}
 
 [tool.pytest.ini_options]
-addopts = "-ra --cov -vv"
+addopts = "-ra -vv"
 {% if cookiecutter.project_backend == "django" %}
 DJANGO_SETTINGS_MODULE = "project.settings"
 pythonpath = ["src"]
 {% endif %}
-
-[tool.coverage.report]
-show_missing = true

--- a/{{cookiecutter.__src_folder_name}}/requirements-dev.in
+++ b/{{cookiecutter.__src_folder_name}}/requirements-dev.in
@@ -5,9 +5,7 @@ cruft
 pip-tools
 
 # Testing Tools
-coverage
 pytest
-pytest-cov
 {% if cookiecutter.project_backend == "django" %}
 pytest-django
 {% endif %}

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/__init__.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/__init__.py
@@ -33,7 +33,7 @@ def create_app(test_config=None):
     if not is_prod_env:
         app.config.from_object("flaskapp.config.development")
     else:
-        app.config.from_object("flaskapp.config.production")  # pragma: no cover
+        app.config.from_object("flaskapp.config.production")
         FlaskMiddleware(
             app,
             exporter=AzureExporter(connection_string=os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", None)),


### PR DESCRIPTION
Unfortunately, we can't generate coverage information from our Playwright tests, we need to write integration/unit tests instead that directly call the files.

Related issues:

https://github.com/microsoft/playwright/issues/9208

https://github.com/microsoft/playwright-python/issues/1029

https://github.com/microsoft/playwright-pytest/issues/190
