### PR TITLE
Remove drop in entrypoint

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/src/entrypoint.sh
+++ b/{{cookiecutter.__src_folder_name}}/src/entrypoint.sh
@@ -8,7 +8,7 @@ python3 -m pip install -e .
 {% if "postgres" in cookiecutter.db_resource %}
 python3 -m flask --app flaskapp db upgrade --directory flaskapp/migrations
 {% endif %}
-python3 -m flask --app flaskapp seed --filename="seed_data.json" --drop
+python3 -m flask --app flaskapp seed --filename="seed_data.json"
 python3 -m gunicorn "flaskapp:create_app()"
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}


### PR DESCRIPTION
The drop parameter is only defined when the resource is mongodb, so its existence is causing bugs for non-mongodb deploys. We also discussed it and don't think its necessary for the entrypoint script. It is most useful for testing, I believe.