### PR TITLE
Remove pytest-flask dependency and use ephemeral-port-reserve

### DIFF
--- a/templates/conftest_flask_mongodb.py
+++ b/templates/conftest_flask_mongodb.py
@@ -1,6 +1,6 @@
 {% macro app() %}
 @pytest.fixture(scope="session")
-def app():
+def app_with_db():
     """Session-wide test `Flask` application."""
     # set up the test database
     dbuser = os.environ["MONGODB_USERNAME"]

--- a/templates/conftest_flask_postgres.py
+++ b/templates/conftest_flask_postgres.py
@@ -1,6 +1,6 @@
 {% macro app() %}
 @pytest.fixture(scope="session")
-def app():
+def app_with_db():
     """Session-wide test `Flask` application."""
     config_override = {
         "TESTING": True,

--- a/{{cookiecutter.__src_folder_name}}/requirements-dev.in
+++ b/{{cookiecutter.__src_folder_name}}/requirements-dev.in
@@ -11,9 +11,6 @@ pytest-cov
 {% if cookiecutter.project_backend == "django" %}
 pytest-django
 {% endif %}
-{% if cookiecutter.project_backend == "flask" %}
-pytest-flask
-{% endif %}
 pytest-playwright
 
 # Linters

--- a/{{cookiecutter.__src_folder_name}}/requirements-dev.in
+++ b/{{cookiecutter.__src_folder_name}}/requirements-dev.in
@@ -11,6 +11,9 @@ pytest-cov
 {% if cookiecutter.project_backend == "django" %}
 pytest-django
 {% endif %}
+{% if cookiecutter.project_backend in ("flask", "fastapi") %}
+ephemeral-port-reserve
+{% endif %}
 pytest-playwright
 
 # Linters

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -121,8 +121,6 @@ def live_server_url(app_with_db):
     seed_data.drop_all()
 {% endif %}
 {% if cookiecutter.project_backend == "flask" %}
-def run_server(app, port):
-    app.run(port=port, debug=False)
 
 
 @pytest.fixture(scope="session")

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -101,7 +101,7 @@ def live_server_url(live_server):
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}
 @pytest.fixture(scope="session")
-def live_server_url(app_with_db):
+def live_server_url():
     """Returns the url of the live server"""
     seed_data.load_from_json()
 

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -7,6 +7,7 @@ import time
 {% if cookiecutter.project_backend == "flask" %}
 import os
 import pathlib
+from multiprocessing import Process
 {% endif %}
 {% if cookiecutter.project_backend == "django" %}
 import os
@@ -15,12 +16,13 @@ import os
 {# third-party library imports #}
 import pytest
 {% if cookiecutter.project_backend == "flask" %}
-from flask import url_for
+import ephemeral_port_reserve
 {% endif %}
 {% if 'mongodb' in cookiecutter.db_resource %}
 import mongoengine as engine
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}
+import ephemeral_port_reserve
 import requests
 import uvicorn
 {% endif %}
@@ -58,23 +60,15 @@ def wait_for_server_ready(
     raise RuntimeError(conn_error)
 
 
-@pytest.fixture(scope="session")
-def free_port() -> int:
-    """
-    Return a free port on localhost
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        addr = s.getsockname()
-        port = addr[1]
-        return port
-
-
-def run_server(port):
+def run_server(port: int):
     uvicorn.run(app, port=port)
 {% endif %}
 
 {% if cookiecutter.project_backend == "flask" %}
+def run_server(app: Flask, port: int):
+    app.run(port=port, debug=False)
+
+
 {% if 'postgres' in cookiecutter.db_resource %}
 {% from 'conftest_flask_postgres.py' import app with context %}
 {% endif %}
@@ -106,20 +100,50 @@ def live_server_url(live_server):
 {% endif %}
 {% if cookiecutter.project_backend == "fastapi" %}
 @pytest.fixture(scope="session")
-def live_server_url(free_port: int):
+def live_server_url(app_with_db):
     """Returns the url of the live server"""
     seed_data.load_from_json()
+
+    # Start the process
+    hostname = ephemeral_port_reserve.LOCALHOST
+    free_port = ephemeral_port_reserve.reserve()
     proc = Process(target=run_server, args=(free_port,), daemon=True)
     proc.start()
-    url = f"http://localhost:{free_port}"
+
+    # Return the URL of the live server once it is ready
+    url = f"http://{hostname}:{port}"
     wait_for_server_ready(url, timeout=10.0, check_interval=0.5)
     yield url
+
+    # Clean up the process and database
     proc.kill()
     seed_data.drop_all()
 {% endif %}
 {% if cookiecutter.project_backend == "flask" %}
-@pytest.fixture(scope="function")
-def live_server_url(app, live_server):
+def run_server(app, port):
+    app.run(port=port, debug=False)
+
+
+@pytest.fixture(scope="session")
+def live_server_url(app_with_db):
     """Returns the url of the live server"""
-    return url_for("pages.index", _external=True)
+
+    # Start the process
+    hostname = ephemeral_port_reserve.LOCALHOST
+    port = ephemeral_port_reserve.reserve(hostname)
+    proc = Process(
+        target=run_server,
+        args=(
+            app_with_db,
+            port,
+        ),
+        daemon=True,
+    )
+    proc.start()
+
+    # Return the URL of the live server
+    yield f"http://{hostname}:{port}"
+
+    # Clean up the process
+    proc.kill()
 {% endif %}

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -112,7 +112,7 @@ def live_server_url(app_with_db):
     proc.start()
 
     # Return the URL of the live server once it is ready
-    url = f"http://{hostname}:{port}"
+    url = f"http://{hostname}:{free_port}"
     wait_for_server_ready(url, timeout=10.0, check_interval=0.5)
     yield url
 
@@ -129,19 +129,19 @@ def live_server_url(app_with_db):
 
     # Start the process
     hostname = ephemeral_port_reserve.LOCALHOST
-    port = ephemeral_port_reserve.reserve(hostname)
+    free_port = ephemeral_port_reserve.reserve(hostname)
     proc = Process(
         target=run_server,
         args=(
             app_with_db,
-            port,
+            free_port,
         ),
         daemon=True,
     )
     proc.start()
 
     # Return the URL of the live server
-    yield f"http://{hostname}:{port}"
+    yield f"http://{hostname}:{free_port}"
 
     # Clean up the process
     proc.kill()

--- a/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/conftest.py
@@ -17,6 +17,7 @@ import os
 import pytest
 {% if cookiecutter.project_backend == "flask" %}
 import ephemeral_port_reserve
+from flask import Flask
 {% endif %}
 {% if 'mongodb' in cookiecutter.db_resource %}
 import mongoengine as engine


### PR DESCRIPTION
This PR removes the pytest-flask dependency and uses an approach similar to what we use for FastAPI. It also moves both Flask and FastAPI to use ephemeral-port-reserve, which should be more stable than the inline function we had for finding a port, and was recommended by David Lord.