### PR TITLE
Update env.py

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/pyproject.toml
+++ b/{{cookiecutter.__src_folder_name}}/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 120
 select = ["E", "F", "I", "UP"]
 ignore = ["D203"]
-extend-exclude = ["flaskapp/migrations/"]
+extend-exclude = ["src/flaskapp/migrations/"]
 
 [tool.ruff.isort]
 {% if cookiecutter.project_backend == "flask" %}

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/migrations/env.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/migrations/env.py
@@ -88,7 +88,7 @@ def run_migrations_online():
             connection=connection,
             target_metadata=get_metadata(),
             process_revision_directives=process_revision_directives,
-            **current_app.extensions["migrate"].configure_args,
+            **current_app.extensions["migrate"].configure_args
         )
 
         with context.begin_transaction():

--- a/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/migrations/env.py
+++ b/{{cookiecutter.__src_folder_name}}/src/flask/flaskapp/migrations/env.py
@@ -88,7 +88,7 @@ def run_migrations_online():
             connection=connection,
             target_metadata=get_metadata(),
             process_revision_directives=process_revision_directives,
-            **current_app.extensions["migrate"].configure_args
+            **current_app.extensions["migrate"].configure_args,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
fixes #284 

With this being generated by the environment file I would like to propose another potential fix to ignore the issue either with:

**1** - manually with a `# ruff: noqa` appended to the top of the file.
or 
**2** - We can also modify the `extend-exclude to include ALL files in the migrations (and not just the version info)

**1** doesn't solve the issue long term either as if we ever need to regenerate the file the problem would appear again (which is the concern currently)

**2** is a little better but this fix is harmless.

I do wonder if this is something that could be fixed on the alembic end (unless they specifically chose not to fix it)

