### PR TITLE
Use relative path for url_for

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/app.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/app.py
@@ -14,7 +14,8 @@ parent_path = pathlib.Path(__file__).parent.parent
 app.mount("/mount", StaticFiles(directory=parent_path / "static"), name="static")
 templates = Jinja2Templates(directory=parent_path / "templates")
 templates.env.globals["prod"] = os.environ.get("RUNNING_IN_PRODUCTION", False)
-
+# Use relative path for url_for, so that it works behind a proxy like Codespaces
+templates.env.globals["url_for"] = app.url_path_for
 
 @app.get("/", response_class=HTMLResponse)
 def index(request: Request):


### PR DESCRIPTION
The FastAPI url_for comes from Starlette and produces an absolute URL, but that URL isnt accurate when youre behind a proxy like Codespaces. This overrides it to use relative URLs instead.

See https://github.com/encode/starlette/issues/843

Fixes https://github.com/Azure-Samples/azure-fastapi-postgres-flexible-aca/issues/13