### PR TITLE
passing checkout option to update_repo, add docs

### DIFF
--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -145,27 +145,32 @@ def update_repo(
         path (pathlib.Path): The parent folder where the will be saved.
         branch (str): The name of the branch to create and push to.
             Defaults to cruft/update.
-        checkout (str): The name of the branch to use from repo to update.
+        checkout (str): The name of the branch to checkout from repo to update.
         **kwargs: Additional keyword arguments to pass to cruft.update as
     """
     # console = console.Console()
     per_file_formatter = logging.Formatter(f'%(asctime)s - {repo} - %(levelname)s - %(message)s')
     file_handler.setFormatter(per_file_formatter)
     url = f"git@github.com:Azure-Samples/{repo}.git"
-    logger.info(f"Cloning from GitHub from {url}")
+    logger.info(f"Cloning {checkout} branch from GitHub from {url}")
     path = path.joinpath(repo)
 
     try:
-        subprocess.check_output(
-            ["git", "clone", url],
-            cwd=path.parent,
-        )
+        if checkout is not None:
+            subprocess.check_output(
+                ["git", "clone", "-b", checkout, url],
+                cwd=path.parent,
+            )
+        else:
+            subprocess.check_output(
+                ["git", "clone", url],
+                cwd=path.parent,
+            )
 
     except subprocess.CalledProcessError as e:
-        logging.warning(f"Could not to clone {url}: {e}.\nThis is likely a non-existent repo.")
+        logging.warning(f"Could not to clone {checkout} branch on {url}: {e}.\nThis is likely a non-existent repo or branch.")
         return None
 
-    logger.info(f"Checking out {branch}.")
     subprocess.check_output(
         ["git", "checkout", "-b", branch],
         text=True,

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -133,7 +133,7 @@ def update_repo(
         repo:str,
         path: pathlib.Path,
         branch:str="cruft/update",
-        checkout_branch:str|None=None,
+        checkout:str|None=None,
         submit_pr:bool=True,
         **kwargs) -> None:
     """
@@ -145,6 +145,7 @@ def update_repo(
         path (pathlib.Path): The parent folder where the will be saved.
         branch (str): The name of the branch to create and push to.
             Defaults to cruft/update.
+        checkout (str): The name of the branch to use from repo to update.
         **kwargs: Additional keyword arguments to pass to cruft.update as
     """
     # console = console.Console()
@@ -164,6 +165,7 @@ def update_repo(
         logging.warning(f"Could not to clone {url}: {e}.\nThis is likely a non-existent repo.")
         return None
 
+    logger.info(f"Checking out {branch}.")
     subprocess.check_output(
         ["git", "checkout", "-b", branch],
         text=True,
@@ -174,7 +176,7 @@ def update_repo(
         path,
         skip_apply_ask=True,
         extra_context=kwargs,
-        checkout=checkout_branch if checkout_branch else None,
+        checkout=checkout if checkout else None,
     )
 
     if not subprocess.check_output(
@@ -243,7 +245,7 @@ def update_repos(
     logger.info(f"Found {len(patterns)} repos matching \"{pattern}\"\n{patterns_str}")
 
     for repo in patterns:
-        update_repo(repo=repo, path=path, branch=branch)
+        update_repo(repo=repo, path=path, branch=branch, checkout=checkout)
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
I think the CLI call was not passing the checkout option to the actual `update_repo` command :) 
Added a logging statement, docs, and consistent naming.
(I haven't tested locally yet, since I don't have it setup yet)