### PR TITLE
Publish Microsoft Authored templates to azure samples browser

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/README.md
+++ b/{{cookiecutter.__src_folder_name}}/README.md
@@ -1,5 +1,35 @@
-{% extends 'abbreviations.txt' %}
-{% block cc %}
+---
+# {% extends 'abbreviations.txt' %}
+# {% block cc %}
+page_type: sample
+languages:
+- azdeveloper
+- python
+- bicep
+- html
+- css
+- scss
+products:
+- azure
+# {% if cookiecutter.project_host == "aca" %}
+- azure-container-apps
+# {% endif %}
+# {% if cookiecutter.project_host == "appservice" %}
+- azure-app-service
+# {% endif %}
+# {% if "postgres" in cookiecutter.db_resource %}
+- azure-postgresql
+# {% endif %}
+# {% if "cosmos" in cookiecutter.db_resource %}
+- azure-cosmos-db
+# {% endif %}
+- azure-pipelines
+urlFragment: azure-{{cookiecutter.project_backend}}-{{cookiecutter.db_resource}}-{{cookiecutter.project_host}}
+name: Deploy {{web_framework}} Application with {{db}} via {{azure_host}} (Python)
+description: This project deploys a web application for a space travel agency using {{web_framework}} with Python. 
+---
+<!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
+
 # Deploy {{web_framework}} Application with {{db}} via Azure Container Apps
 
 This project deploys a web application for a space travel agency using {{web_framework}}. The application can be deployed to Azure with {{azure_host}} using the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview).

--- a/{{cookiecutter.__src_folder_name}}/README.md
+++ b/{{cookiecutter.__src_folder_name}}/README.md
@@ -30,6 +30,8 @@ description: This project deploys a web application for a space travel agency us
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
+{% extends 'abbreviations.txt' %}
+{% block cc %}
 # Deploy {{web_framework}} Application with {{db}} via Azure Container Apps
 
 This project deploys a web application for a space travel agency using {{web_framework}}. The application can be deployed to Azure with {{azure_host}} using the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview).


### PR DESCRIPTION
Publish `cookiecutter-relecloud` template to azure samples browser.

@pamelafox    According to the video introduction in the Readme, when we tried to generate templates locally through cookiecutter-relecloud, we encountered an FailedHookException error. Therefore, we cannot verify the accuracy of this PR. Do you have any ideas on how to generate these templates?

@hemarina for notification.